### PR TITLE
Miscellaneous fixes (#147)

### DIFF
--- a/component-samples/rv/src/main/java/org/fido/iot/sample/RvContextListener.java
+++ b/component-samples/rv/src/main/java/org/fido/iot/sample/RvContextListener.java
@@ -74,7 +74,7 @@ public class RvContextListener implements ServletContextListener {
             switch (request.getAsNumber(Const.SM_MSG_ID).intValue()) {
               case Const.TO0_HELLO:
               case Const.TO0_OWNER_SIGN:
-                return createTo0Service(cs, ds, ods);
+                return createTo0Service(cs, ds);
               case Const.TO1_HELLO_RV:
               case Const.TO1_PROVE_TO_RV:
                 return createTo1Service(cs, ds, ods);
@@ -117,15 +117,14 @@ public class RvContextListener implements ServletContextListener {
   public void contextDestroyed(ServletContextEvent sce) {}
 
   private To0ServerService createTo0Service(CryptoService cs,
-                                            DataSource ds,
-                                            OnDieService ods) {
+                                            DataSource ds) {
     return new To0ServerService() {
       private To0ServerStorage storage;
 
       @Override
       public To0ServerStorage getStorage() {
         if (storage == null) {
-          storage = new To0AllowListDenyListDbStorage(cs, ds, ods);
+          storage = new To0AllowListDenyListDbStorage(cs, ds);
         }
         return storage;
       }

--- a/protocol-samples/http-server-di-sample/src/main/java/org/fido/iot/sample/DiApp.java
+++ b/protocol-samples/http-server-di-sample/src/main/java/org/fido/iot/sample/DiApp.java
@@ -15,6 +15,7 @@ import org.apache.catalina.startup.Tomcat;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.fido.iot.api.AssignCustomerServlet;
 import org.fido.iot.api.DiApiServlet;
+import org.fido.iot.api.RvInfoServlet;
 import org.fido.iot.protocol.Const;
 import org.h2.server.web.DbStarter;
 import org.h2.server.web.WebServlet;
@@ -87,7 +88,7 @@ public class DiApp {
     // OnDie cert cache is included with the protocol samples.
     Path odcPath = Paths.get(System.getProperty("user.dir"),"../", "onDieCache");
 
-    ctx.addParameter("ods.cacheDir", odcPath.toString());
+    ctx.addParameter("ods.cacheDir", odcPath.toUri().toString());
     ctx.addParameter("ods.autoUpdate", "false");
     ctx.addParameter("ods.zipArtifactUrl", "");
     ctx.addParameter("ods.checkRevocations",
@@ -109,6 +110,9 @@ public class DiApp {
 
     wrapper = tomcat.addServlet(ctx, "AssignCustomerApi", new AssignCustomerServlet());
     wrapper.addMapping("/api/v1/assign/*");
+
+    wrapper = tomcat.addServlet(ctx, "UpdateRvInfoApi", new RvInfoServlet());
+    wrapper.addMapping("/api/v1/rvinfo/*");
 
     wrapper = tomcat.addServlet(ctx, "H2Console", new WebServlet());
     wrapper.addMapping("/console/*");

--- a/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fido/iot/sample/To0To1ContextListener.java
+++ b/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fido/iot/sample/To0To1ContextListener.java
@@ -66,7 +66,7 @@ public class To0To1ContextListener implements ServletContextListener {
         switch (request.getAsNumber(Const.SM_MSG_ID).intValue()) {
           case Const.TO0_HELLO:
           case Const.TO0_OWNER_SIGN:
-            return createTo0Service(cs, ds, ods);
+            return createTo0Service(cs, ds);
           case Const.TO1_HELLO_RV:
           case Const.TO1_PROVE_TO_RV:
             return createTo1Service(cs, ds, ods);
@@ -104,14 +104,14 @@ public class To0To1ContextListener implements ServletContextListener {
   public void contextDestroyed(ServletContextEvent sce) {
   }
 
-  private To0ServerService createTo0Service(CryptoService cs, DataSource ds, OnDieService ods) {
+  private To0ServerService createTo0Service(CryptoService cs, DataSource ds) {
     return new To0ServerService() {
       private To0ServerStorage storage;
 
       @Override
       public To0ServerStorage getStorage() {
         if (storage == null) {
-          storage = new To0DbStorage(cs, ds, ods);
+          storage = new To0DbStorage(cs, ds);
         }
         return storage;
       }

--- a/protocol-samples/http-server-to2-sample/src/main/java/org/fido/iot/sample/To2ServerApp.java
+++ b/protocol-samples/http-server-to2-sample/src/main/java/org/fido/iot/sample/To2ServerApp.java
@@ -75,7 +75,7 @@ public class To2ServerApp {
     Path odcPath = Paths.get(System.getProperty("user.dir"),"../", "onDieCache");
 
     System.out.println("Working Directory = " + odcPath.toString());
-    ctx.addParameter("ods.cacheDir",  odcPath.toString());
+    ctx.addParameter("ods.cacheDir",  odcPath.toUri().toString());
     ctx.addParameter("ods.autoUpdate", "false");
     ctx.addParameter("ods.zipArtifactUrl", "");
     ctx.addParameter("ods.checkRevocations", "true");

--- a/protocol/src/main/java/org/fido/iot/protocol/To0ServerService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To0ServerService.java
@@ -54,7 +54,7 @@ public abstract class To0ServerService extends MessagingService {
     if ((cryptoService.getPublicKeyType(publicKey) == Const.PK_SECP256R1)
         || (cryptoService.getPublicKeyType(publicKey) == Const.PK_SECP384R1)) {
 
-      cryptoService.verifyVoucher(voucher, getStorage().getOnDieService());
+      cryptoService.verifyVoucher(voucher);
     }
 
     byte[] nonce3 = getStorage().getNonce3();

--- a/protocol/src/main/java/org/fido/iot/protocol/To0ServerStorage.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To0ServerStorage.java
@@ -34,6 +34,4 @@ public interface To0ServerStorage extends StorageEvents {
    */
   long storeRedirectBlob(Composite voucher, long requestedWait, byte[] signedBlob);
 
-  OnDieService getOnDieService();
-
 }

--- a/protocol/src/main/java/org/fido/iot/protocol/VoucherExtensionService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/VoucherExtensionService.java
@@ -44,7 +44,7 @@ public class VoucherExtensionService {
     PublicKey prevOwnerPubKey;
     //For the first entry, the hash is SHA[TO2.ProveOPHdr.OVHeader|\|TO2.ProveOPHdr.HMac].
     Composite entries = voucher.getAsComposite(Const.OV_ENTRIES);
-    if (entries.size() == 0) {
+    if (entries == null || entries.size() == 0) {
       byte[] ovhBytes = ovh.toBytes();
       byte[] macBytes = mac.toBytes();
       ByteBuffer prevInfo = ByteBuffer.allocate(ovhBytes.length + macBytes.length);

--- a/protocol/src/main/java/org/fido/iot/protocol/ondie/OnDieService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/ondie/OnDieService.java
@@ -6,18 +6,16 @@ package org.fido.iot.protocol.ondie;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.net.URL;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.cert.CRL;
 import java.security.cert.CRLException;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 
 import org.bouncycastle.asn1.x509.CRLDistPoint;
@@ -107,6 +105,14 @@ public class OnDieService {
       return false;
     }
 
+    // validate that the cert chain is anchored to correct root CA
+    try {
+      if (!isRootCa(((X509Certificate) certChain.get(certChain.size() - 1)).getEncoded())) {
+        return false;
+      }
+    } catch (CertificateEncodingException ex) {
+      return false;
+    }
     return validateSignature(certChain.get(0).getPublicKey(), signedData, signature);
   }
 

--- a/util/http-dispatchers/http-server-dispatcher/src/test/java/org/fido/iot/sample/TestListener.java
+++ b/util/http-dispatchers/http-server-dispatcher/src/test/java/org/fido/iot/sample/TestListener.java
@@ -87,11 +87,7 @@ public class TestListener implements ServletContextListener {
       public void failed(Composite request, Composite reply) {
 
       }
-
-      @Override
-      public OnDieService getOnDieService() {
-        return null;
-      }
+      
     };
 
     To0ServerService to0Service = new To0ServerService() {

--- a/util/storage-samples/storage-di-sample/src/main/java/org/fido/iot/storage/DiDbStorage.java
+++ b/util/storage-samples/storage-di-sample/src/main/java/org/fido/iot/storage/DiDbStorage.java
@@ -137,7 +137,10 @@ public class DiDbStorage implements DiServerStorage {
       // EPID type device
       Certificate[] issuerChain = resolver.getCertChain(keyType);
       publicKey = cryptoService.encode(issuerChain[0].getPublicKey(),
-              cryptoService.getCompatibleEncoding(issuerChain[0].getPublicKey()));
+             Const.PK_ENC_CRYPTO);
+      chain = Composite.newArray();
+      int hashType = getCryptoService().getCompatibleHashType(issuerChain[0].getPublicKey());
+      chainHash = cryptoService.hash(hashType, chain.toBytes());
     } else if (keyType == Const.PK_ONDIE_ECDSA_384) {
       // Ondie ECDSA type device
       // build the cert chain and hash for the OnDie ECDSA device

--- a/util/storage-samples/storage-rv-sample/src/main/java/org/fido/iot/storage/To0AllowListDenyListDbStorage.java
+++ b/util/storage-samples/storage-rv-sample/src/main/java/org/fido/iot/storage/To0AllowListDenyListDbStorage.java
@@ -33,9 +33,8 @@ public class To0AllowListDenyListDbStorage extends To0DbStorage {
    * @param dataSource A SQL datasource.
    */
   public To0AllowListDenyListDbStorage(CryptoService cryptoService,
-                                       DataSource dataSource,
-                                       OnDieService ods) {
-    super(cryptoService, dataSource, ods);
+                                       DataSource dataSource) {
+    super(cryptoService, dataSource);
   }
 
   /**

--- a/util/storage-samples/storage-rv-sample/src/main/java/org/fido/iot/storage/To0DbStorage.java
+++ b/util/storage-samples/storage-rv-sample/src/main/java/org/fido/iot/storage/To0DbStorage.java
@@ -27,7 +27,6 @@ public class To0DbStorage implements To0ServerStorage {
 
   private final CryptoService cryptoService;
   protected final DataSource dataSource;
-  private final OnDieService onDieService;
   private byte[] nonce3;
 
   /**
@@ -35,12 +34,10 @@ public class To0DbStorage implements To0ServerStorage {
    *
    * @param cryptoService A crypto Service.
    * @param dataSource    A SQL datasource.
-   * @param ods service object used for OnDie operations
    */
-  public To0DbStorage(CryptoService cryptoService, DataSource dataSource, OnDieService ods) {
+  public To0DbStorage(CryptoService cryptoService, DataSource dataSource) {
     this.cryptoService = cryptoService;
     this.dataSource = dataSource;
-    this.onDieService = ods;
   }
 
   @Override
@@ -62,7 +59,10 @@ public class To0DbStorage implements To0ServerStorage {
     PublicKey pubKey = getCryptoService().decode(encodedKey);
     String ownerX509String = getCryptoService().getFingerPrint(pubKey);
     pubKey = getCryptoService().getDevicePublicKey(voucher);
-    Composite deviceX509 = getCryptoService().encode(pubKey, Const.PK_ENC_X509);
+    Composite deviceX509 = Composite.newArray();
+    if (pubKey != null) {
+      deviceX509 = getCryptoService().encode(pubKey, Const.PK_ENC_X509);
+    }
 
     String sql = ""
         + "MERGE INTO RV_REDIRECTS  "
@@ -187,10 +187,6 @@ public class To0DbStorage implements To0ServerStorage {
 
   protected CryptoService getCryptoService() {
     return cryptoService;
-  }
-
-  public OnDieService getOnDieService() {
-    return onDieService;
   }
 
   protected String getToken(Composite request) {

--- a/util/storage-samples/storage-rv-sample/src/test/java/org/fido/iot/storage/RvsStorageTest.java
+++ b/util/storage-samples/storage-rv-sample/src/test/java/org/fido/iot/storage/RvsStorageTest.java
@@ -137,15 +137,14 @@ public class RvsStorageTest {
   }
 
   private To0ServerService createTo0Service(CryptoService cs,
-                                            DataSource ds,
-                                            OnDieService ods) {
+                                            DataSource ds) {
     return new To0ServerService() {
       private To0ServerStorage storage;
 
       @Override
       public To0ServerStorage getStorage() {
         if (storage == null) {
-          storage = new To0DbStorage(cs, ds, ods);
+          storage = new To0DbStorage(cs, ds);
         }
         return storage;
       }
@@ -342,7 +341,7 @@ public class RvsStorageTest {
         switch (request.getAsNumber(Const.SM_MSG_ID).intValue()) {
           case Const.TO0_HELLO:
           case Const.TO0_OWNER_SIGN:
-            return createTo0Service(cs, ds, ods);
+            return createTo0Service(cs, ds);
           case Const.TO1_HELLO_RV:
           case Const.TO1_PROVE_TO_RV:
             return createTo1Service(cs, ds, ods);


### PR DESCRIPTION
Added missing RVInfo API to protocol-sample for DI Server.

Fixed incorrect public key type for EPID devices.

Fixed Windows OnDie config error.

Fixed voucher generation error with EPID devices.

Fixed voucher validation issue with OnDie ECDSA

- Voucher leaf certificate should be the first certificate
(0) instead of certificate 1. After fixing this issue there
is no longer any need for a specific check for OnDie so the
corresponding code can be removed.

- In addition, code to validate the root CA is OnDie is moved
to the OnDie signature validation function.

Signed-off-by: Easterday, John <john.easterday@intel.com>