### PR TITLE
fix error with default SI configuration (#152)

### DIFF
--- a/util/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerServiceInfoModule.java
+++ b/util/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerServiceInfoModule.java
@@ -54,7 +54,7 @@ public class OwnerServiceInfoModule implements ServiceInfoModule {
       throw new RuntimeException(e);
     }
 
-    if (!sviString.equals("null")) {
+    if (sviString != null && !sviString.equals("null")) {
       String[] keys = sviString.split(SVI_ARRAY_DELIMETER);
       for (String key : keys) {
         String[] keyElements = key.split(SVI_ENTRY_DELIMETER);


### PR DESCRIPTION
* adding OnDie documentation

Signed-off-by: Easterday, John <john.easterday@intel.com>

* clean up README, add notes to component README files.

Signed-off-by: Easterday, John <john.easterday@intel.com>

* fix links in README files

Signed-off-by: Easterday, John <john.easterday@intel.com>

* Add missing rvinfo API to protocol-sample DI

Signed-off-by: Easterday, John <john.easterday@intel.com>

* fix incorrect publickey type for EPID devices.

Signed-off-by: Easterday, John <john.easterday@intel.com>

* fix Windows OnDie config error

Signed-off-by: Easterday, John <john.easterday@intel.com>

* fix voucher generation error with EPID devices

Signed-off-by: Easterday, John <john.easterday@intel.com>

* fix voucher validation

Voucher leaf certificate should be the first certificate
(0) instead of certificate 1. After fixing this issue there
is no longer any need for a specific check for OnDie so the
corresponding code can be removed.

In addition, code to validate the root CA is OnDie is moved
to the OnDie signature validation function.

Signed-off-by: Easterday, John <john.easterday@intel.com>

* add missing file

Signed-off-by: Easterday, John <john.easterday@intel.com>

* fix default case when no SI properties have been defined

Signed-off-by: Easterday, John <john.easterday@intel.com>