### PR TITLE
Fixing multiple T00 retries leading to memory leak (#173)

### DIFF
--- a/component-samples/demo/owner/docker-compose.yml
+++ b/component-samples/demo/owner/docker-compose.yml
@@ -25,5 +25,5 @@ services:
     mem_limit: 500m
     mem_reservation: 200m
     cpu_shares: 1024
-    pids_limit: 100
+    pids_limit: 500
     network_mode: host


### PR DESCRIPTION
Fixing multiple TO0 retries leading to memory leak by
    * Increasing PID limit from 100 to 500.
    * Explicitly closing HTTP Client threads once it is created.

Signed-off-by: Davis Benny <davis.benny@intel.com>